### PR TITLE
Add Sobrevivir al Racionamiento skeleton

### DIFF
--- a/sobrevivir-racionamiento/README.md
+++ b/sobrevivir-racionamiento/README.md
@@ -1,0 +1,23 @@
+# Sobrevivir al Racionamiento
+
+Minijuego educativo que simula la supervivencia de una familia durante los años del hambre en el franquismo. Todo el juego funciona con HTML, CSS y JavaScript sin dependencias adicionales.
+
+## Estructura
+- `index.html` punto de entrada.
+- `css/` estilos generales y tema visual de 1942.
+- `js/` lógica de juego dividida en modulos.
+- `assets/` espacio para imagenes y datos.
+
+## Ejecución
+
+En entornos con Node disponible puede lanzarse un servidor estático simple:
+
+```bash
+npx serve sobrevivir-racionamiento
+```
+
+O bien abrir `index.html` directamente en un navegador moderno.
+
+## Pruebas
+
+Ejecute `node tests/run-tests.js` para ejecutar tests básicos sobre la estructura del proyecto.

--- a/sobrevivir-racionamiento/css/main.css
+++ b/sobrevivir-racionamiento/css/main.css
@@ -1,0 +1,15 @@
+/* Estilos generales */
+body {
+    margin: 0;
+    font-family: 'Courier New', monospace;
+    background-color: var(--papel-viejo);
+    color: var(--tinta-negra);
+}
+
+#game-container {
+    width: 100%;
+    min-height: var(--alto-minimo);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr;
+}

--- a/sobrevivir-racionamiento/css/responsive.css
+++ b/sobrevivir-racionamiento/css/responsive.css
@@ -1,0 +1,24 @@
+@media (max-width: 767px) {
+    #game-container {
+        grid-template-columns: 1fr;
+        grid-template-rows: 80px 200px 150px 150px;
+        gap: 10px;
+        padding: 10px;
+    }
+}
+
+@media (min-width: 768px) and (max-width: 1023px) {
+    #game-container {
+        grid-template-columns: 180px 1fr 180px;
+        max-width: 900px;
+        margin: 0 auto;
+    }
+}
+
+@media (min-width: 1024px) {
+    #game-container {
+        max-width: var(--ancho-maximo);
+        margin: 20px auto;
+        grid-template-columns: 250px 1fr 250px;
+    }
+}

--- a/sobrevivir-racionamiento/css/vintage-1942.css
+++ b/sobrevivir-racionamiento/css/vintage-1942.css
@@ -1,0 +1,40 @@
+:root {
+    --sepia-oscuro: #8B4513;
+    --sepia-claro: #D2691E;
+    --papel-viejo: #F5E6D3;
+    --tinta-negra: #2F1B14;
+    --rojo-urgente: #8B0000;
+    --verde-salud: #228B22;
+    --amarillo-hambre: #DAA520;
+
+    --fuente-titulo: 'Courier New', monospace;
+    --fuente-texto: 'Times New Roman', serif;
+    --ancho-maximo: 1200px;
+    --alto-minimo: 600px;
+    --transicion-suave: all 0.3s ease;
+}
+
+.header-1942 {
+    font-family: var(--fuente-titulo);
+    background: linear-gradient(45deg, var(--sepia-oscuro), var(--sepia-claro));
+    color: var(--papel-viejo);
+    padding: 20px;
+    border-bottom: 3px solid var(--tinta-negra);
+    box-shadow: inset 0 0 20px rgba(0,0,0,0.3);
+}
+
+.boton-1942 {
+    background: linear-gradient(145deg, var(--sepia-claro), var(--sepia-oscuro));
+    border: 3px solid var(--tinta-negra);
+    color: var(--papel-viejo);
+    font-family: var(--fuente-titulo);
+    font-weight: bold;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: var(--transicion-suave);
+}
+
+.boton-1942:hover {
+    transform: translateY(-2px);
+}

--- a/sobrevivir-racionamiento/index.html
+++ b/sobrevivir-racionamiento/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sobrevivir al Racionamiento - Febrero 1942</title>
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/vintage-1942.css">
+    <link rel="stylesheet" href="css/responsive.css">
+
+    <meta name="description" content="Simulación educativa sobre supervivencia familiar durante el franquismo">
+    <meta name="keywords" content="franquismo, educación, historia, memoria histórica">
+</head>
+<body>
+    <div id="game-container"></div>
+
+    <!-- Scripts -->
+    <script src="js/historical-data.js"></script>
+    <script src="js/family-system.js"></script>
+    <script src="js/market-system.js"></script>
+    <script src="js/events-system.js"></script>
+    <script src="js/ui-controller.js"></script>
+    <script src="js/game-engine.js"></script>
+</body>
+</html>

--- a/sobrevivir-racionamiento/js/events-system.js
+++ b/sobrevivir-racionamiento/js/events-system.js
@@ -1,0 +1,22 @@
+const EVENTOS_HISTORICOS = {
+    redada_policial: {
+        probabilidad: 0.15,
+        efectos: { riesgo: 30 }
+    },
+    ayuda_familiar_pueblo: {
+        probabilidad: 0.10,
+        efectos: { comida_extra: 2 }
+    }
+};
+
+function generarEventoAleatorio(dia, estado) {
+    const keys = Object.keys(EVENTOS_HISTORICOS);
+    for (const evento of keys) {
+        const cfg = EVENTOS_HISTORICOS[evento];
+        let prob = cfg.probabilidad;
+        if (Math.random() < prob) {
+            return { tipo: evento, efectos: cfg.efectos };
+        }
+    }
+    return null;
+}

--- a/sobrevivir-racionamiento/js/family-system.js
+++ b/sobrevivir-racionamiento/js/family-system.js
@@ -1,0 +1,25 @@
+function calcularAlimentacionFamiliar(comidaConsumida, miembros) {
+    let alimentacionTotal = 0;
+    miembros.forEach(miembro => {
+        const necesidadBase = miembro.edad < 12 ? 1800 : 2200;
+        const consumoReal = comidaConsumida[miembro.id] || 0;
+        const porcentaje = (consumoReal / necesidadBase) * 100;
+        alimentacionTotal += Math.min(porcentaje, 100);
+    });
+    return alimentacionTotal / miembros.length;
+}
+
+function calcularSaludFamiliar(familiaEstado) {
+    familiaEstado.forEach(miembro => {
+        const alimentacion = miembro.alimentacionActual || 0;
+        let cambio = 0;
+        if (alimentacion >= 80) cambio = 2;
+        else if (alimentacion >= 60) cambio = 0;
+        else if (alimentacion >= 40) cambio = -5;
+        else if (alimentacion >= 20) cambio = -10;
+        else cambio = -20;
+        if (miembro.edad < 10) cambio *= 1.5;
+        if (miembro.genero === 'mujer' && miembro.edad > 25) cambio *= 1.2;
+        miembro.salud = Math.max(0, Math.min(100, miembro.salud + cambio));
+    });
+}

--- a/sobrevivir-racionamiento/js/game-engine.js
+++ b/sobrevivir-racionamiento/js/game-engine.js
@@ -1,0 +1,39 @@
+const STORAGE_KEY = 'sobrevivir_racionamiento_v1';
+
+const gameState = {
+    version: '1.0',
+    currentDay: 1,
+    family: {
+        padre: { salud: 100, hambre: 100, moral: 100, edad: 35, id: 'padre', genero: 'hombre' },
+        madre: { salud: 100, hambre: 100, moral: 100, edad: 33, id: 'madre', genero: 'mujer' },
+        hijo: { salud: 100, hambre: 100, moral: 100, edad: 12, id: 'hijo', genero: 'hombre' },
+        hija: { salud: 100, hambre: 100, moral: 100, edad: 8, id: 'hija', genero: 'mujer' }
+    },
+    resources: {
+        dinero: 12,
+        comida: { pan: 3, aceite: 7, garbanzos: 1, arroz: 4, huevos: 1 }
+    },
+    decisions: [],
+    riesgoPolicial: 15,
+    gameCompleted: false
+};
+
+function saveGame() {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(gameState));
+    } catch (error) {
+        console.warn('No se pudo guardar progreso:', error);
+    }
+}
+
+function loadGame() {
+    try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        return saved ? JSON.parse(saved) : null;
+    } catch (error) {
+        console.warn('No se pudo cargar progreso:', error);
+        return null;
+    }
+}
+
+window.addEventListener('beforeunload', saveGame);

--- a/sobrevivir-racionamiento/js/historical-data.js
+++ b/sobrevivir-racionamiento/js/historical-data.js
@@ -1,0 +1,16 @@
+const HISTORICAL_DATA = {
+    eventos_diarios: {
+        lunes: {
+            tipo: 'racion_oficial',
+            titulo: 'La Cartilla de Racionamiento',
+            descripcion: 'Carmen ha ido temprano a recoger la racion semanal...'
+        }
+    },
+    eventos_aleatorios: {
+        redada_policial: {
+            probabilidad: 0.15,
+            titulo: 'Control Policial',
+            descripcion: 'La Guardia Civil esta registrando el edificio...'
+        }
+    }
+};

--- a/sobrevivir-racionamiento/js/market-system.js
+++ b/sobrevivir-racionamiento/js/market-system.js
@@ -1,0 +1,25 @@
+const PRECIOS_OFICIALES = {
+    pan: 0.80,
+    aceite: 2.50,
+    carne: 4.00,
+    huevos: 0.30,
+    arroz: 1.20
+};
+
+const MULTIPLICADORES_ESTRAPERLO = {
+    pan: { min: 2.5, max: 4.0 },
+    aceite: { min: 3.0, max: 5.0 },
+    carne: { min: 3.5, max: 6.0 },
+    huevos: { min: 4.0, max: 7.0 },
+    arroz: { min: 2.0, max: 4.0 }
+};
+
+function calcularPrecioEstraperlo(producto, dia, riesgoPolicial, demanda) {
+    const base = PRECIOS_OFICIALES[producto];
+    const mult = MULTIPLICADORES_ESTRAPERLO[producto];
+    let factor = mult.min + (mult.max - mult.min) * Math.random();
+    factor *= (1 + (riesgoPolicial / 100) * 0.5);
+    factor *= (1 + (demanda / 100) * 0.3);
+    factor *= (1 + (dia / 7) * 0.2);
+    return Math.round(base * factor * 100) / 100;
+}

--- a/sobrevivir-racionamiento/js/ui-controller.js
+++ b/sobrevivir-racionamiento/js/ui-controller.js
@@ -1,0 +1,28 @@
+const DEVICE_CAPABILITIES = {
+    isMobile: window.innerWidth < 768,
+    isTablet: window.innerWidth >= 768 && window.innerWidth < 1024,
+    isDesktop: window.innerWidth >= 1024,
+    supportsLocalStorage: (() => {
+        try {
+            localStorage.setItem('test', 'test');
+            localStorage.removeItem('test');
+            return true;
+        } catch (e) {
+            return false;
+        }
+    })(),
+    supportsDragDrop: 'draggable' in document.createElement('div')
+};
+
+function adaptInterface() {
+    const container = document.getElementById('game-container');
+    if (DEVICE_CAPABILITIES.isMobile) {
+        container.classList.add('mobile-layout');
+    } else if (DEVICE_CAPABILITIES.isTablet) {
+        container.classList.add('tablet-layout');
+    } else {
+        container.classList.add('desktop-layout');
+    }
+}
+
+window.addEventListener('load', adaptInterface);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+
+const TESTS = {
+    'Archivo HTML existe': () => fs.existsSync('sobrevivir-racionamiento/index.html'),
+    'Contiene game-container': () => {
+        const html = fs.readFileSync('sobrevivir-racionamiento/index.html', 'utf-8');
+        return html.includes('id="game-container"');
+    }
+};
+
+function runBasicTests() {
+    const results = {};
+    for (const t in TESTS) {
+        try {
+            results[t] = TESTS[t]();
+        } catch (e) {
+            results[t] = false;
+        }
+    }
+    console.log(results);
+    const failed = Object.values(results).some(v => !v);
+    return failed ? 1 : 0;
+}
+
+process.exit(runBasicTests());


### PR DESCRIPTION
## Summary
- create `sobrevivir-racionamiento` project with HTML, CSS and JS files
- add minimal local storage and event logic
- provide README with usage instructions
- include basic node-based tests

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_684f1ec1c6d0832d8926148b07cbe0e2