### PR TITLE
Add service worker

### DIFF
--- a/sobrevivir-racionamiento/index.html
+++ b/sobrevivir-racionamiento/index.html
@@ -48,5 +48,12 @@
     <script src="js/events-system.js"></script>
     <script src="js/ui-controller.js"></script>
     <script src="js/game-engine.js"></script>
+    <script>
+        window.addEventListener('load', () => {
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('sw.js');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/sobrevivir-racionamiento/sw.js
+++ b/sobrevivir-racionamiento/sw.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'v1';
+const FILES_TO_CACHE = [
+  '/',
+  'index.html',
+  'css/main.css',
+  'css/vintage-1942.css',
+  'css/responsive.css',
+  'js/historical-data.js',
+  'js/family-system.js',
+  'js/market-system.js',
+  'js/events-system.js',
+  'js/ui-controller.js',
+  'js/game-engine.js'
+  // Add new files here to make sure they're cached
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(FILES_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});


### PR DESCRIPTION
## Summary
- enable offline support with a basic service worker
- register the worker after page load

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_684f439f23d0832d9e21a3323b490b68