### PR TITLE
Add nextDay export and storage tests

### DIFF
--- a/sobrevivir-racionamiento/index.html
+++ b/sobrevivir-racionamiento/index.html
@@ -28,6 +28,11 @@
                 <div class="plate-drop" data-miembro="hijo">Hijo</div>
                 <div class="plate-drop" data-miembro="hija">Hija</div>
             </div>
+            <div id="phase-actions" class="phase-actions">
+                <button id="action-plan" class="boton-1942">Planificar</button>
+                <button id="action-market" class="boton-1942">Mercado</button>
+                <button id="action-end" class="boton-1942">Terminar Día</button>
+            </div>
         </main>
 
         <aside id="family-sidebar" class="sidebar right">

--- a/sobrevivir-racionamiento/js/game-engine.js
+++ b/sobrevivir-racionamiento/js/game-engine.js
@@ -45,7 +45,9 @@ function loadGame() {
     }
 }
 
-window.addEventListener('beforeunload', saveGame);
+if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', saveGame);
+}
 
 function recordStatus() {
     gameState.history.riesgo.push(gameState.riesgoPolicial);
@@ -86,4 +88,16 @@ function advanceDay() {
     gameState.currentDay += 1;
 }
 
-window.addEventListener('load', recordStatus);
+function nextDay() {
+    advanceDay();
+    return gameState.currentDay;
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('load', recordStatus);
+    window.nextDay = nextDay;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { gameState, saveGame, loadGame, nextDay };
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,10 +1,65 @@
 const fs = require('fs');
+const vm = require('vm');
+const os = require('os');
+const path = require('path');
+
+function createTempStorage(dir) {
+    const file = path.join(dir, 'storage.json');
+    return {
+        setItem: (k, v) => {
+            let data = {};
+            if (fs.existsSync(file)) {
+                data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            }
+            data[k] = v;
+            fs.writeFileSync(file, JSON.stringify(data));
+        },
+        getItem: (k) => {
+            if (!fs.existsSync(file)) return null;
+            const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+            return data[k] || null;
+        }
+    };
+}
+
+function loadGameEngine() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ls-'));
+    const context = {
+        localStorage: createTempStorage(dir),
+        window: { addEventListener: () => {} },
+        document: { getElementById: () => null },
+        module: { exports: {} }
+    };
+    vm.createContext(context);
+    const code = fs.readFileSync('sobrevivir-racionamiento/js/game-engine.js', 'utf8');
+    vm.runInContext(code, context);
+    return context.module.exports;
+}
 
 const TESTS = {
     'Archivo HTML existe': () => fs.existsSync('sobrevivir-racionamiento/index.html'),
     'Contiene game-container': () => {
         const html = fs.readFileSync('sobrevivir-racionamiento/index.html', 'utf-8');
         return html.includes('id="game-container"');
+    },
+    'localStorage save/load funciona': () => {
+        const engine = loadGameEngine();
+        engine.gameState.currentDay = 3;
+        engine.saveGame();
+        engine.gameState.currentDay = 1;
+        const loaded = engine.loadGame();
+        return loaded && loaded.currentDay === 3;
+    },
+    'nextDay avanza un dia': () => {
+        const engine = loadGameEngine();
+        const prev = engine.gameState.currentDay;
+        if (typeof engine.nextDay !== 'function') return false;
+        engine.nextDay();
+        return engine.gameState.currentDay === prev + 1;
+    },
+    'index.html tiene botones de fase': () => {
+        const html = fs.readFileSync('sobrevivir-racionamiento/index.html', 'utf-8');
+        return html.includes('id="phase-actions"') && html.includes('<button');
     }
 };
 


### PR DESCRIPTION
## Summary
- expose `nextDay` from the game engine so it can be tested and used externally
- add placeholder phase action buttons in `index.html`
- expand test suite to check HTML buttons, nextDay, and save/load using a temporary localStorage

## Testing
- `node tests/run-tests.js`

------
https://chatgpt.com/codex/tasks/task_b_684f447a3cbc832d8b63ff7fd1b53b0a